### PR TITLE
Fix Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,27 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const repository = process.env.GITHUB_REPOSITORY ?? '';
-const repositoryName = repository.split('/')[1] ?? '';
-const isUserOrOrgSite = repositoryName.toLowerCase().endsWith('.github.io');
-const basePath = repositoryName && !isUserOrOrgSite ? `/${repositoryName}/` : '/';
+const FALLBACK_REPOSITORY_NAME = 'sefosa85';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: basePath,
-  plugins: [react()],
-  optimizeDeps: {
-    exclude: ['lucide-react'],
-  },
+export default defineConfig(({ command }) => {
+  const repository = process.env.GITHUB_REPOSITORY ?? '';
+  const repositoryNameFromEnv = repository.split('/')[1] ?? '';
+
+  const repositoryName =
+    repositoryNameFromEnv || (command === 'build' ? FALLBACK_REPOSITORY_NAME : '');
+
+  const isUserOrOrgSite = repositoryName.toLowerCase().endsWith('.github.io');
+  const basePath =
+    command === 'build' && repositoryName && !isUserOrOrgSite
+      ? `/${repositoryName}/`
+      : '/';
+
+  return {
+    base: basePath,
+    plugins: [react()],
+    optimizeDeps: {
+      exclude: ['lucide-react'],
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- update the Vite configuration to derive the correct base path during production builds so the site works on GitHub Pages

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1aebb998c832b8d554d0151925025